### PR TITLE
Add pkgconfig file configuration and link to ws2_32 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,4 +83,4 @@ configure_file(
 
 # Install pkg-config file
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/statsd-cpp.pc
-    DESTINATION lib/pkgconfig)
+    DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,6 +44,7 @@ add_executable(
 )
 
 IF (WIN32)
+  target_link_libraries(statsd ws2_32)
   target_link_libraries(statsd-test statsd_static ws2_32)
 ELSE()
   target_link_libraries(statsd-test statsd pthread)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,6 @@ ELSE()
   target_link_libraries(statsd-test statsd pthread)
 ENDIF()
 
-
 enable_testing()
 
 function(add_memcheck_test name binary)
@@ -69,3 +68,19 @@ install(TARGETS statsd_static statsd
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
 )
+
+# Configure pkg-config file
+set(ADDITIONAL_LIBS "")
+if (WIN32)
+    set(ADDITIONAL_LIBS "-lws2_32")
+endif()
+
+configure_file(
+    ${CMAKE_CURRENT_SOURCE_DIR}/statsd-cpp.pc.in
+    ${CMAKE_CURRENT_BINARY_DIR}/statsd-cpp.pc
+    @ONLY
+)
+
+# Install pkg-config file
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/statsd-cpp.pc
+    DESTINATION lib/pkgconfig)

--- a/statsd-cpp.pc.in
+++ b/statsd-cpp.pc.in
@@ -1,0 +1,11 @@
+prefix=@CMAKE_INSTALL_PREFIX@
+exec_prefix=${prefix}
+libdir=${exec_prefix}/lib
+includedir=${prefix}/include
+
+Name: statsd-cpp
+Description: statsd-cpp
+Version: @STATSD_VERSION@
+
+Libs: -L${libdir} -lstatsd_static @ADDITIONAL_LIBS@
+Cflags: -I${includedir}


### PR DESCRIPTION
The following PR adds pkgconfig file configuration with properly generated statsd-cpp.pc. 

The results of the PR were pkgconfig files configured sucessfully and ws2_32 sucessfully linked in windows.

