### PR TITLE
Update statsd args

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,7 @@
 # For the full copyright and license information, please view the LICENSE
 # file that was distributed with this source code.
 ##
-cmake_minimum_required(VERSION 2.8.7)
+cmake_minimum_required(VERSION 3.12)
 
 project(StatsD CXX)
 
@@ -28,7 +28,7 @@ set(CMAKE_MEMORYCHECK_COMMAND_OPTIONS "--error-exitcode=1 -v --track-origins=yes
 find_file(HAVE_VALGRIND "valgrind")
 
 add_definitions(
-    -std=c++11
+    -std=c++17
     -Wall
     -pedantic
 )

--- a/include/statsd.hpp
+++ b/include/statsd.hpp
@@ -9,17 +9,14 @@
 #pragma once
 
 #include <string>
-#include <random>
-# include <iostream>
+#include <string_view>
+#include <vector>
 
 #ifdef _WIN32
 #include <winsock2.h>
 #else
 #include <netinet/in.h>
 #endif
-
-# define statsd_error(message) \
-	std::cerr << "StatsD: " << message << std::endl;
 
 class statsd
 {
@@ -42,7 +39,7 @@ public:
      * @param value         The ellapsed time (ms) to log
      * @param sample_rate   The rate (0-1) for sampling.
      */
-    static void timing(const std::string& key, const int64_t value, const float sample_rate = 1.0);
+    static void timing(std::string_view key, const int64_t value, const float sample_rate = 1.0f);
 
     /**
      * Increments one or more stats counters
@@ -50,7 +47,7 @@ public:
      * @param key           The metric(s) to increment.
      * @param sample_rate   The rate (0-1) for sampling.
      */
-    static void increment(const std::string& key, const float sample_rate = 1.0);
+    static void increment(std::string_view key, const float sample_rate = 1.0f);
 
     /**
      * Decrements one or more stats counters.
@@ -58,7 +55,7 @@ public:
      * @param key           The metric(s) to decrement.
      * @param sample_rate   The rate (0-1) for sampling.
      */
-    static void decrement(const std::string& key, const float sample_rate = 1.0);
+    static void decrement(std::string_view key, const float sample_rate = 1.0f);
 
     /**
      * Count is the default statsd method for counting
@@ -67,7 +64,7 @@ public:
      * @param value         The count value
      * @param sample_rate   The rate (0-1) for sampling.
      */
-    static void count(const std::string& key, const int64_t value, const float sample_rate = 1.0);
+    static void count(std::string_view key, const int64_t value, const float sample_rate = 1.0f);
 
     /**
      * Gauge
@@ -76,7 +73,7 @@ public:
      * @param value         The count value
      * @param sample_rate   The rate (0-1) for sampling.
      */
-    static void gauge(const std::string& key, const int64_t value, const float sample_rate = 1.0);
+    static void gauge(std::string_view key, const int64_t value, const float sample_rate = 1.0f);
 
     /**
      * gaugeIncBy
@@ -85,7 +82,7 @@ public:
      * @param value         The increment value
      * @param sample_rate   The rate (0-1) for sampling.
      */
-    static void gaugeIncBy(const std::string& key, const int64_t value, const float sample_rate = 1.0);
+    static void gaugeIncBy(std::string_view key, const int64_t value, const float sample_rate = 1.0f);
 
     /**
      * gaugeDecBy
@@ -94,7 +91,7 @@ public:
      * @param value         The decrement value
      * @param sample_rate   The rate (0-1) for sampling.
      */
-    static void gaugeDecBy(const std::string& key, const int64_t value, const float sample_rate = 1.0);
+    static void gaugeDecBy(std::string_view key, const int64_t value, const float sample_rate = 1.0f);
 
     /**
      * Set
@@ -103,7 +100,7 @@ public:
      * @param value         The count value
      * @param sample_rate   The rate (0-1) for sampling.
      */
-    static void set(const std::string& key, const int64_t value, const float sample_rate = 1.0);
+    static void set(std::string_view key, const int64_t value, const float sample_rate = 1.0f);
 
 
     /**
@@ -111,7 +108,7 @@ public:
     * 
     * @param prefix         The prefix to prepend
     */
-    static void setPrefix(const std::string& _prefix);
+    static void setPrefix(std::string_view _prefix);
 
     /**
      * setGlobalTags
@@ -131,7 +128,7 @@ public:
      * @param key   The key of metric(s)
      * @return      The normalized key
      */
-    static std::string normalize(const std::string& key);
+    static std::string normalize(std::string_view key);
 
     /**
      * Prepare message
@@ -144,12 +141,12 @@ public:
      * @return              The message
      */
     static std::string prepare(
-        const std::string& key,
+        std::string_view key,
         const int64_t value,
         const std::vector<std::string> tags,
         const float sample_rate,
-        const std::string& unit,
-        const std::string& sign = ""
+        std::string_view unit,
+        std::string_view sign = std::string_view{}
     );
 
     /**
@@ -182,11 +179,11 @@ private:
      * @param sign          The sign (for gauges)
      */
     static void send(
-        const std::string& key,
+        std::string_view key,
         const int64_t value,
         const float sample_rate,
-        const std::string& unit,
-        const std::string& sign = ""
+        std::string_view unit,
+        std::string_view sign = std::string_view{}
     );
 
     /**

--- a/src/statsd.cpp
+++ b/src/statsd.cpp
@@ -14,7 +14,6 @@
 #include <cstdlib>
 #include <sstream>
 #include <iomanip>
-#include <string>
 
 #include <random>
 #include <iostream>
@@ -31,6 +30,9 @@
 #include <unistd.h>
 #include <netdb.h>
 #endif
+
+# define statsd_error(message) \
+	std::cerr << "StatsD: " << message << std::endl;
 
 statsd::statsd_t statsd::info;
 std::string statsd::prefix;
@@ -121,42 +123,42 @@ int statsd::open(const std::string& host, int16_t port, int mode)
     return 4;
 }
 
-void statsd::timing(const std::string& key, const int64_t value, const float sample_rate)
+void statsd::timing(std::string_view key, const int64_t value, const float sample_rate)
 {
     send(key, value, sample_rate, "ms");
 }
 
-void statsd::increment(const std::string& key, const float sample_rate)
+void statsd::increment(std::string_view key, const float sample_rate)
 {
     count(key, 1, sample_rate);
 }
 
-void statsd::decrement(const std::string& key, const float sample_rate)
+void statsd::decrement(std::string_view key, const float sample_rate)
 {
     count(key, -1, sample_rate);
 }
 
-void statsd::count(const std::string& key, const int64_t value, const float sample_rate)
+void statsd::count(std::string_view key, const int64_t value, const float sample_rate)
 {
     send(key, value, sample_rate, "c");
 }
 
-void statsd::gaugeIncBy(const std::string& key, const int64_t value, const float sample_rate)
+void statsd::gaugeIncBy(std::string_view key, const int64_t value, const float sample_rate)
 {
     send(key, value, sample_rate, "g", "+");
 }
 
-void statsd::gaugeDecBy(const std::string& key, const int64_t value, const float sample_rate)
+void statsd::gaugeDecBy(std::string_view key, const int64_t value, const float sample_rate)
 {
     send(key, value, sample_rate, "g", "-");
 }
 
-void statsd::gauge(const std::string& key, const int64_t value, const float sample_rate)
+void statsd::gauge(std::string_view key, const int64_t value, const float sample_rate)
 {
     send(key, value, sample_rate, "g");
 }
 
-void statsd::set(const std::string& key, const int64_t value, const float sample_rate)
+void statsd::set(std::string_view key, const int64_t value, const float sample_rate)
 {
     send(key, value, sample_rate, "s");
 }
@@ -174,7 +176,7 @@ void statsd::close()
     }
 }
 
-void statsd::setPrefix(const std::string& _prefix) {
+void statsd::setPrefix(std::string_view _prefix) {
     prefix = _prefix;
 }
 
@@ -193,11 +195,11 @@ void statsd::setGlobalTags(std::vector<std::string> global_tags){
 const std::vector<std::string> empty_tags;
 
 void statsd::send(
-    const std::string& key,
+    std::string_view key,
     const int64_t value,
     const float sample_rate,
-    const std::string& unit,
-    const std::string& sign
+    std::string_view unit,
+    std::string_view sign
 )
 {
     if (info.sock == -1)
@@ -252,7 +254,7 @@ bool statsd::should_send(const float sample_rate)
     }
 }
 
-std::string statsd::normalize(const std::string& key)
+std::string statsd::normalize(std::string_view key)
 {
     std::string retval;
 
@@ -272,12 +274,12 @@ std::string statsd::normalize(const std::string& key)
 }
 
 std::string statsd::prepare(
-    const std::string& key,
+    std::string_view key,
     const int64_t value,
     const std::vector<std::string> tags,
     const float sample_rate,
-    const std::string& unit,
-    const std::string& sign
+    std::string_view unit,
+    std::string_view sign
 )
 {
     bool tagging = false;


### PR DESCRIPTION
This PR bumps the minimum CMake version to 3.12 (it was released in 2018). The reason is that version 2.8.7 no longer builds with the newer `cmake` releases, and the current one that I have is cmake version 3.31.4.

We would have to bump up that version for the provisioning to work. Note that I bumped to a very conservative version. Children born at the year of 3.12 release are already going to the school.

Removed `<iostream>` and `<random>` from the public header. There is nothing in the API that pulls in those features, so they should not be pulled in.

Pass arguments to statsd via `std::string_view` as opposed to `const std::string&`. This avoids allocating and deallocating string temporaries when making statsd calls. `std::string_view` simply transparently forwards string-like data to the statsd internals, be that `const char*`, an `std::string` or another `string_view`. At the same token, `sample_rate` was defaulted to `1.0f` (float), instead of `1.0` (double). There is no need for implicit `double` -> `float` conversions in the default argument.

[Edit: `statsd-test` program works after these changes.]